### PR TITLE
remove useless message of the cmake file in switch example

### DIFF
--- a/apps/bk7236/switch_example/main/CMakeLists.txt
+++ b/apps/bk7236/switch_example/main/CMakeLists.txt
@@ -4,10 +4,6 @@ armino_component_register(SRCS "main.c"
                     EMBED_FILES "device_info.json"
                                 "onboarding_config.json"
                     )
-message("@@@@@@@@@@ switch example ${CMAKE_C_FLAGS}")
-
-#mbedtls
-#set(MBEDTLS_ECP_DP_CURVE25519_ENABLED "y")
 
 set(PROJECT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../")
 set(STDK_IOT_CORE_USE_DEFINED_CONFIG "y")


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to the SmartThings Device SDK(STDK for short) project.
Please read & check through marking lists before submitting pull requests.
-->

## Marking lists
- [ ] I have read the [Contributing Guidelines](https://github.com/SmartThingsCommunity/st-device-sdk-c/blob/master/CONTRIBUTING.md).
- [ ] I have read the [Samsung Individual CLA](https://github.com/SmartThingsCommunity/st-device-sdk-c/blob/master/doc/SAMSUNGCLA.docx) and agree with it
     * We (SmartThings Device SDK team) may ask you to sign it for larger changes. In this case, once we receive it, we'll be able to accept your pull requests according to relevant laws.

- I submitted this PR against the correct branch:
  - [ ] This pull-request is based on the latest [develop](https://github.com/SmartThingsCommunity/st-device-sdk-c-ref/tree/develop) branch.
  - [ ] I have ensured local tests pass about my code changes.

## License

Your contribution will be licensed under the [Apache License Ver2.0](https://github.com/SmartThingsCommunity/st-device-sdk-c-ref/blob/master/LICENSE).
